### PR TITLE
timezonefinder 6.2.0 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<38]
+  # numba not available for s390x
+  skip: true  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,17 +19,16 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - poetry-core >=1.0.0
-    - cffi
-    - setuptools
   host:
     - python
     - pip
-    - poetry
+    - poetry-core >=1.0.0
+    - cffi >=1.15.1,<2
+    - setuptools
   run:
     - python
-    - numpy {{numpy}}
-    - h3-py
+    - numpy >=1.18,<2
+    - h3-py >=3.7.6,<4
     - numba
     - cffi >=1.15.1
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "timezonefinder" %}
-{% set version = "6.1.5" %}
-{% set sha256 = "07b9c217920fc128bd800ab1165b4f9d14242aeb07d9e668ef3987185bc758c0" %}
+{% set version = "6.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -9,34 +8,41 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: d41fd2650bb4221fae5a61f9c2767158f9727c4aaca95e24da86394feb704220
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-#  noarch: python
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:
-    - poetry
+    - {{ compiler('c') }}
+    - poetry-core >=1.0.0
     - cffi
     - setuptools
-    - {{ compiler('c') }}
   host:
+    - python
     - pip
-    - python 3
     - poetry
   run:
-    - python 3
-    - numpy
+    - python
+    - numpy {{numpy}}
     - h3-py
     - numba
-    - cffi
+    - cffi >=1.15.1
+  run_constrained:
+    - numba >=0.56,<1
+    - pytz >=2022.7.1
 
 test:
   imports:
     - timezonefinder
     - timezonefinder.timezonefinder
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://timezonefinder.michelfe.it/gui
@@ -47,10 +53,12 @@ about:
   description: |
     This is a fast and lightweight python package for looking up the corresponding timezone for given 
     corresponding timezone for a given lat/lng on earth entirely offline.
-
+  doc_url: https://timezonefinder.readthedocs.io
   dev_url: https://github.com/jannikmi/timezonefinder
 
 extra:
   recipe-maintainers:
     - snowman2
     - jannikmi
+  skip-lints:
+    - missing_wheel

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,4 @@
+from timezonefinder import TimezoneFinder
+
+tz = TimezoneFinder().timezone_at(lng=13.358, lat=52.5061)
+assert tz == "Europe/Berlin"


### PR DESCRIPTION
timezonefinder 6.2.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-3776] 
- dev_url (pypi): https://github.com/jannikmi/timezonefinder/tree/6.2.0
- conda-forge: https://github.com/conda-forge/timezonefinder-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/timezonefinder


### Explanation of changes:

- fix recipe
- skip s390x because `numba` is not there
- add one simple test


[PKG-3776]: https://anaconda.atlassian.net/browse/PKG-3776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ